### PR TITLE
Remove incorrect nuget token expiry comment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,5 +33,3 @@ jobs:
       run: dotnet nuget push bin/FSharp.Core.Fluent.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_ORG_TOKEN_2021 }} --skip-duplicate
 
 # NUGET_ORG_TOKEN_2021 is listed in "Repository secrets" in https://github.com/fsprojects/FSharp.Core.Fluent/settings/secrets/actions
-# note, the nuget org token expires around July 2023
-


### PR DESCRIPTION
As of May 2025 the nuget token works fine and has been refreshed.